### PR TITLE
Fix/increase decrease

### DIFF
--- a/src/main/CalypsoCardAdapter.h
+++ b/src/main/CalypsoCardAdapter.h
@@ -679,32 +679,32 @@ private:
     /**
      *
      */
-    bool mIsExtendedModeSupported;
+    bool mIsExtendedModeSupported = false;
 
     /**
      *
      */
-    bool mIsRatificationOnDeselectSupported;
+    bool mIsRatificationOnDeselectSupported = false;
 
     /**
      *
      */
-    bool mIsSvFeatureAvailable;
+    bool mIsSvFeatureAvailable = false;
 
     /**
      *
      */
-    bool mIsPinFeatureAvailable;
+    bool mIsPinFeatureAvailable = false;
 
     /**
      *
      */
-    bool mIsPkiModeSupported;
+    bool mIsPkiModeSupported = false;
 
     /**
      *
      */
-    bool mIsDfInvalidated;
+    bool mIsDfInvalidated = false;
 
     /**
      *
@@ -739,7 +739,7 @@ private:
     /**
      *
      */
-    bool mIsModificationCounterInBytes;
+    bool mIsModificationCounterInBytes = false;
 
     /**
      *
@@ -799,7 +799,7 @@ private:
     /**
      *
      */
-    bool mIsHce;
+    bool mIsHce = false;
 
     /**
      *

--- a/src/main/CmdCardIncreaseOrDecrease.cpp
+++ b/src/main/CmdCardIncreaseOrDecrease.cpp
@@ -106,7 +106,8 @@ int CmdCardIncreaseOrDecrease::getIncDecValue() const
 const std::map<const int, const std::shared_ptr<StatusProperties>>
     CmdCardIncreaseOrDecrease::initStatusTable()
 {
-    std::map<const int, const std::shared_ptr<StatusProperties>> m;
+    std::map<const int, const std::shared_ptr<StatusProperties>> m =
+        AbstractApduCommand::STATUS_TABLE;
 
     m.insert({0x6400,
               std::make_shared<StatusProperties>("Too many modifications in session.",


### PR DESCRIPTION
this fixes two issues: 
* extended mode is not activated by default (most of the time uninitialized bools will be initialized to something different than 0)
* properly initialize IncreaseOrDecrease command's status table to recognize success